### PR TITLE
ci: add GitHub Actions workflow; misc updates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,9 @@
 1. Run `git status` to check for uncommitted changes
    - If uncommitted changes exist, alert me immediately and stop
    - Do not proceed until I have confirmed how to handle them (commit, stash, or discard)
-2. Check if `.claude/mission.md` exists and read the project mission and context.
+2. Check if `.claude/mission.md` exists and read it.
+   - Follow **all** file references listed under "External References" — read each one (shared-instructions, backlog, incoming requests, etc.)
+   - If a path uses `$DOC_ROOT`, resolve it via the environment variable defined in `~/.claude/settings.json`.
 3. Check if `plan/` exists in the project root.
    - If `plan/plan.md` exists, summarize what has been done and what the next step is.
    - If `plan/feature.md` exists, read the current feature scope.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,19 +5,19 @@
    - If uncommitted changes exist, alert me immediately and stop
    - Do not proceed until I have confirmed how to handle them (commit, stash, or discard)
 2. Check if `.claude/mission.md` exists and read the project mission and context.
-3. Check if `.claude/plan.md` exists.
-   If it does, read it and summarize what has been done and what the next step is.
-   If it does not exist, ask me how I would like to proceed.
-4. Check if `.claude/feature.md` exists and read the current feature scope.
+3. Read the project's plan directory (see mission.md for location).
+   - If `plan.md` exists, summarize what has been done and what the next step is.
+   - If `feature.md` exists, read the current feature scope.
+   - If neither exists, ask me how I would like to proceed.
 
 ### During a session
 After completing each step in the plan:
-- Mark it as `[x]` done in `.claude/plan.md`
+- Mark it as `[x]` done in `plan.md`
 - Add a brief note about what was done and any important decisions made
 - Mark the next step as `[~]` in progress
 
 ### Ending a session
-- Update `.claude/plan.md` with the current status of all steps
+- Update `plan.md` with the current status of all steps
 - Add a "Last session" note summarizing what was completed and what comes next
 - Note any README.md changes that will be needed when the feature is complete
 
@@ -63,22 +63,25 @@ dotnet test -c Release
 - Never commit failing tests
 - Use conventional commits: `feat:`, `fix:`, `test:`, `docs:`
 - Never merge to main — leave that for me to review and merge
+- When merging a completed feature back to the originating branch, use `--no-ff` (no fast-forward) to preserve the feature branch history as a merge commit
 
 ## Feature Workflow
 
-### Planning features
-- Multiple features can be planned ahead in `.claude/features-planned/`
-- Each file represents one feature and they are executed in order (e.g. `01-feature-name.md`, `02-feature-name.md`)
-- When starting a new feature, check `features-planned/` first for the next planned feature
+Feature planning and tracking is stored outside the git repo to avoid unnecessary commits and permission prompts. The plan directory location is defined in `.claude/mission.md` under "Plan directory".
 
 ### Starting a feature
 When told to start a new feature:
 1. Ask for the feature name and goal if not provided
 2. Note the current branch as the originating branch for the feature
 3. Create a new branch: `git checkout -b feature/<feature-name>`
-4. Create `.claude/feature.md` with goal, scope, acceptance criteria, and done condition
-5. Create or update `.claude/plan.md` with the steps to implement the feature
+4. Create `feature.md` in the plan directory with goal, scope, acceptance criteria, and done condition
+5. Create or update `plan.md` in the plan directory with the steps to implement the feature
 6. Confirm the plan before starting any code changes
+
+### During implementation
+- Update `plan.md` continuously as changes are made
+- Commit to the feature branch at logical milestones
+- Run tests before each commit
 
 ### Completing implementation
 When all planned steps are done:
@@ -88,44 +91,27 @@ When all planned steps are done:
 - Do NOT close the feature — wait for the user to confirm it is done
 
 ### Closing a feature (only when the user says it is done)
-- All acceptance criteria in `.claude/feature.md` are met
+- All acceptance criteria in `feature.md` are met
 - All tests pass
 - README.md has been updated to reflect the new feature
-- `.claude/feature.md` is archived to `.claude/features-done/<feature-name>.md` and both `.claude/feature.md` and `.claude/plan.md` should be deleted
-- Remove the corresponding file from `.claude/features-planned/` if one exists
+- Archive `feature.md` to a `done/` subdirectory in the plan directory and delete `plan.md`
 - A final commit is made with message: `feat: <feature-name> complete`
-- Merge to originating branch and delete feature branch only when the user explicitly asks
+- Merge to originating branch with `--no-ff` and delete feature branch only when the user explicitly asks
 
 ## Feature Requests (cross-project)
 
-Projects can request features from each other via `.claude/requests.md`.
+Cross-project requests are handled via `mission.md` — see the "Incoming requests" reference there for the central location.
 
-- Read `~/.claude/projects.md` (or `$OBSIDIAN_VAULT/Tharga/projects.md`) to discover other projects
-- Read `.claude/requests.md` on startup — show pending requests and new notifications to the user
-- Writing feature requests to other projects is **exempt from the cross-project guard**
-- For mono-repos: requests go to the root, not sub-projects (see projects.md for details)
+- On startup, check `mission.md` for the requests location and show pending requests to the user
+- Writing feature requests is **exempt from the cross-project guard**
 - Never mark a request as done without user confirmation
-- When a request is completed: update status to Done and write a notification back to the requester's `.claude/requests.md`
-
-### Request format
-```markdown
-## Pending
-
-### <short description>
-- **From:** <project name> (`<project path>`)
-- **Date:** <YYYY-MM-DD>
-- **Priority:** <High/Medium/Low>
-- **Description:** <what is needed and why>
-- **Status:** Pending
-
-## Notifications
-
-### <short description> — DONE
-- **From:** <project name> (`<project path>`)
-- **Completed:** <YYYY-MM-DD>
-- **Summary:** <what was done>
-- **Branch/Version:** <branch or version>
-```
+- When a request is completed:
+  1. Update its status to Done in the central requests file, add completion date and summary
+  2. Add a follow-up entry under `## Uppföljning` at the top of the central requests file so the consuming project knows to update:
+     ```
+     - [ ] <Consuming project> ska uppdatera <package> till <version> — <kort beskrivning av vad som är nytt>
+     ```
+  3. The follow-up is checked off when the consuming project has updated and verified the new version
 
 ## Backlog Hygiene
 - When a task from the backlog (in `mission.md` or linked external files) is completed, mark it as done or remove it

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -98,34 +98,12 @@ When all planned steps are done:
 
 ## Feature Requests (cross-project)
 
-Projects can request features from each other via `.claude/requests.md`.
+Cross-project requests are handled via `mission.md` — see the "Incoming requests" reference there for the central location.
 
-- Read `~/.claude/projects.md` (or `$OBSIDIAN_VAULT/Tharga/projects.md`) to discover other projects
-- Read `.claude/requests.md` on startup — show pending requests and new notifications to the user
-- Writing feature requests to other projects is **exempt from the cross-project guard**
-- For mono-repos: requests go to the root, not sub-projects (see projects.md for details)
+- On startup, check `mission.md` for the requests location and show pending requests to the user
+- Writing feature requests is **exempt from the cross-project guard**
 - Never mark a request as done without user confirmation
-- When a request is completed: update status to Done and write a notification back to the requester's `.claude/requests.md`
-
-### Request format
-```markdown
-## Pending
-
-### <short description>
-- **From:** <project name> (`<project path>`)
-- **Date:** <YYYY-MM-DD>
-- **Priority:** <High/Medium/Low>
-- **Description:** <what is needed and why>
-- **Status:** Pending
-
-## Notifications
-
-### <short description> — DONE
-- **From:** <project name> (`<project path>`)
-- **Completed:** <YYYY-MM-DD>
-- **Summary:** <what was done>
-- **Branch/Version:** <branch or version>
-```
+- When a request is completed: update its status to Done in the central file, add completion date and summary
 
 ## Backlog Hygiene
 - When a task from the backlog (in `mission.md` or linked external files) is completed, mark it as done or remove it

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,19 +5,19 @@
    - If uncommitted changes exist, alert me immediately and stop
    - Do not proceed until I have confirmed how to handle them (commit, stash, or discard)
 2. Check if `.claude/mission.md` exists and read the project mission and context.
-3. Check if `.claude/plan.md` exists.
-   If it does, read it and summarize what has been done and what the next step is.
-   If it does not exist, ask me how I would like to proceed.
-4. Check if `.claude/feature.md` exists and read the current feature scope.
+3. Check if `plan/` exists in the project root.
+   - If `plan/plan.md` exists, summarize what has been done and what the next step is.
+   - If `plan/feature.md` exists, read the current feature scope.
+   - If neither exists, ask me how I would like to proceed.
 
 ### During a session
 After completing each step in the plan:
-- Mark it as `[x]` done in `.claude/plan.md`
+- Mark it as `[x]` done in `plan/plan.md`
 - Add a brief note about what was done and any important decisions made
 - Mark the next step as `[~]` in progress
 
 ### Ending a session
-- Update `.claude/plan.md` with the current status of all steps
+- Update `plan/plan.md` with the current status of all steps
 - Add a "Last session" note summarizing what was completed and what comes next
 - Note any README.md changes that will be needed when the feature is complete
 
@@ -62,23 +62,33 @@ dotnet test -c Release
 - Commit at logical milestones (e.g. a component is complete and tested)
 - Never commit failing tests
 - Use conventional commits: `feat:`, `fix:`, `test:`, `docs:`
-- Never merge to main — leave that for me to review and merge
+- Never merge to master/main — leave that for me to review and merge
+- Default branch strategy: `master` is production, `develop` is integration. Feature branches branch from and merge to `develop`.
+- When merging a completed feature back to the originating branch, use `--no-ff` (no fast-forward) to preserve the feature branch history as a merge commit
 
 ## Feature Workflow
 
+Active feature tracking lives in `plan/` in the project root (committed with the feature branch).
+Planned and completed features are stored externally in the **Plan directory** defined in `.claude/mission.md`.
+
 ### Planning features
-- Multiple features can be planned ahead in `.claude/features-planned/`
-- Each file represents one feature and they are executed in order (e.g. `01-feature-name.md`, `02-feature-name.md`)
-- When starting a new feature, check `features-planned/` first for the next planned feature
+- Future features are stored in the Plan directory under `planned/`
+- Each file represents one feature, executed in order (e.g. `01-feature-name.md`, `02-feature-name.md`)
+- When starting a new feature, check the Obsidian `planned/` directory first
 
 ### Starting a feature
 When told to start a new feature:
 1. Ask for the feature name and goal if not provided
 2. Note the current branch as the originating branch for the feature
 3. Create a new branch: `git checkout -b feature/<feature-name>`
-4. Create `.claude/feature.md` with goal, scope, acceptance criteria, and done condition
-5. Create or update `.claude/plan.md` with the steps to implement the feature
+4. Create `plan/feature.md` with goal, scope, acceptance criteria, and done condition
+5. Create `plan/plan.md` with the steps to implement the feature
 6. Confirm the plan before starting any code changes
+
+### During implementation
+- Update `plan/plan.md` continuously as changes are made
+- Commit `plan/` together with code changes at logical milestones
+- Run tests before each commit
 
 ### Completing implementation
 When all planned steps are done:
@@ -88,13 +98,13 @@ When all planned steps are done:
 - Do NOT close the feature — wait for the user to confirm it is done
 
 ### Closing a feature (only when the user says it is done)
-- All acceptance criteria in `.claude/feature.md` are met
+- All acceptance criteria in `plan/feature.md` are met
 - All tests pass
 - README.md has been updated to reflect the new feature
-- `.claude/feature.md` is archived to `.claude/features-done/<feature-name>.md` and both `.claude/feature.md` and `.claude/plan.md` should be deleted
-- Remove the corresponding file from `.claude/features-planned/` if one exists
+- Archive `plan/feature.md` to the Plan directory `done/<feature-name>.md`
+- Delete the `plan/` directory from the project
 - A final commit is made with message: `feat: <feature-name> complete`
-- Merge to originating branch and delete feature branch only when the user explicitly asks
+- Merge to originating branch with `--no-ff` and delete feature branch only when the user explicitly asks
 
 ## Feature Requests (cross-project)
 
@@ -103,7 +113,13 @@ Cross-project requests are handled via `mission.md` — see the "Incoming reques
 - On startup, check `mission.md` for the requests location and show pending requests to the user
 - Writing feature requests is **exempt from the cross-project guard**
 - Never mark a request as done without user confirmation
-- When a request is completed: update its status to Done in the central file, add completion date and summary
+- When a request is completed:
+  1. Update its status to Done in the central requests file, add completion date and summary
+  2. Add a follow-up entry under `## Uppföljning` at the top of the central requests file so the consuming project knows to update:
+     ```
+     - [ ] <Consuming project> ska uppdatera <package> till <version> — <kort beskrivning av vad som är nytt>
+     ```
+  3. The follow-up is checked off when the consuming project has updated and verified the new version
 
 ## Backlog Hygiene
 - When a task from the backlog (in `mission.md` or linked external files) is completed, mark it as done or remove it

--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -3,5 +3,7 @@
 Shared Blazor components.
 
 ## External References
+- **Shared instructions**: `$DOC_ROOT/Tharga/shared-instructions.md`
+- **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Blazor`
 - **Backlog**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Toolkit\Blazor.md`
 - **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md` — check for pending requests for this project on startup

--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -4,3 +4,4 @@ Shared Blazor components.
 
 ## External References
 - **Backlog**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Toolkit\Blazor.md`
+- **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md` — check for pending requests for this project on startup

--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -7,3 +7,4 @@ Shared Blazor components.
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Blazor`
 - **Backlog**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Toolkit\Blazor.md`
 - **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md` — check for pending requests for this project on startup
+- **Eplicta requests**: `$DEV_ROOT/Eplicta/plan/requests.md` — check for requests from Eplicta on startup

--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -1,6 +1,11 @@
 # Mission: Tharga.Blazor
 
-Shared Blazor components.
+Shared Blazor components with Radzen UI.
+
+- **Type**: Tool
 
 ## External References
-- **Backlog**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Toolkit\Blazor.md`
+- **Shared instructions**: `$DOC_ROOT/Tharga/shared-instructions.md`
+- **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Blazor`
+- **Backlog**: `$DOC_ROOT/Tharga/Toolkit/Blazor.md`
+- **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md` — check sections "Tharga.Blazor" on startup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,269 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  MAJOR_MINOR: '2.1'
+
+permissions:
+  contents: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore 2>&1 | tee build.log
+
+      - name: Check warnings
+        run: |
+          WARNING_COUNT=$(grep -c " warning " build.log || true)
+          echo "Build warnings: $WARNING_COUNT"
+          if [ "$WARNING_COUNT" -gt 15 ]; then
+            echo "::error::Build has $WARNING_COUNT warnings (threshold: 15)"
+            exit 1
+          fi
+
+      - name: Test with coverage
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Compute version
+        id: version
+        run: |
+          LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
+            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | head -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            PATCH=0
+          else
+            PATCH=$(echo "$LATEST_TAG" | sed "s/${MAJOR_MINOR}\.\([0-9]*\)/\1/")
+            PATCH=$((PATCH + 1))
+          fi
+
+          VERSION="${MAJOR_MINOR}.${PATCH}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Computed version: $VERSION (previous: $LATEST_TAG)"
+
+      - name: Compute pre-release version
+        id: preversion
+        if: github.ref != 'refs/heads/master'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PRE_BASE="${VERSION}-pre"
+
+          LATEST_PRE=$(git tag -l "${PRE_BASE}.*" --sort=-v:refname | head -1)
+
+          if [ -z "$LATEST_PRE" ]; then
+            COUNTER=1
+          else
+            COUNTER=$(echo "$LATEST_PRE" | sed "s/.*-pre\.\([0-9]*\)/\1/")
+            COUNTER=$((COUNTER + 1))
+          fi
+
+          PRE_VERSION="${PRE_BASE}.${COUNTER}"
+          echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed pre-release version: $PRE_VERSION"
+
+      - name: Pack
+        run: |
+          dotnet pack Tharga.Blazor/Tharga.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts/
+
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Build for CodeQL
+        run: dotnet build -c Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+
+  release:
+    needs: [build, security]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    environment: release
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts/
+
+      - name: Compute version
+        id: version
+        run: |
+          LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
+            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | head -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            PATCH=0
+          else
+            PATCH=$(echo "$LATEST_TAG" | sed "s/${MAJOR_MINOR}\.\([0-9]*\)/\1/")
+            PATCH=$((PATCH + 1))
+          fi
+
+          VERSION="${MAJOR_MINOR}.${PATCH}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Push to NuGet
+        run: |
+          for pkg in ./artifacts/*.nupkg; do
+            echo "Pushing $pkg..."
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+          done
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES_FLAG=""
+          if [ -n "${{ steps.version.outputs.previous_tag }}" ]; then
+            NOTES_FLAG="--notes-start-tag ${{ steps.version.outputs.previous_tag }}"
+          fi
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            $NOTES_FLAG \
+            ./artifacts/*.nupkg
+
+      - name: Comment released version on merged PR
+        if: always()
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(echo "${{ github.event.head_commit.message }}" | grep -oP 'Merge pull request #\K\d+' | head -1)
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --body "Released as **v${{ steps.version.outputs.version }}** — https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }}"
+          else
+            echo "No PR number found in commit message — skipping PR comment."
+          fi
+
+  prerelease:
+    needs: [build, security]
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master' && github.event_name == 'pull_request'
+    environment: prerelease
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts/
+
+      - name: Compute pre-release version
+        id: version
+        run: |
+          LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
+            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | head -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            PATCH=0
+          else
+            PATCH=$(echo "$LATEST_TAG" | sed "s/${MAJOR_MINOR}\.\([0-9]*\)/\1/")
+            PATCH=$((PATCH + 1))
+          fi
+
+          PRE_BASE="${MAJOR_MINOR}.${PATCH}-pre"
+          LATEST_PRE=$(git tag -l "${PRE_BASE}.*" --sort=-v:refname | head -1)
+
+          if [ -z "$LATEST_PRE" ]; then
+            COUNTER=1
+          else
+            COUNTER=$(echo "$LATEST_PRE" | sed "s/.*-pre\.\([0-9]*\)/\1/")
+            COUNTER=$((COUNTER + 1))
+          fi
+
+          VERSION="${PRE_BASE}.${COUNTER}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Push to NuGet
+        run: |
+          for pkg in ./artifacts/*.nupkg; do
+            echo "Pushing $pkg..."
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+          done
+
+      - name: Create GitHub Pre-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }} (pre-release)" \
+            --notes "Pre-release from \`${{ github.head_ref }}\` branch." \
+            --prerelease \
+            ./artifacts/*.nupkg

--- a/Tharga.Blazor.Tests/Tharga.Blazor.Tests.csproj
+++ b/Tharga.Blazor.Tests/Tharga.Blazor.Tests.csproj
@@ -10,9 +10,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Tharga.Blazor/Tharga.Blazor.csproj
+++ b/Tharga.Blazor/Tharga.Blazor.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
     <PackageReference Include="Radzen.Blazor" Version="9.0.4" />
-    <PackageReference Include="Tharga.Toolkit" Version="1.15.19" />
+    <PackageReference Include="Tharga.Toolkit" Version="1.15.21" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Add `.github/workflows/build.yml` for build, test, coverage, CodeQL, and NuGet publish — mirrors the Tharga.Crawler reference. MAJOR_MINOR=2.1, .NET 9/10, packs `Tharga.Blazor`.
- Update NuGet packages.
- Update Claude Code instructions.

## Follow-up after merge
- Configure `NUGET_API_KEY` (and optionally `CODECOV_TOKEN`) in repo secrets.
- Create `release` and `prerelease` environments in GitHub settings.
- Disable the old Azure DevOps pipeline once the new workflow is validated.
- Switch branching strategy to feature branches → master (per shared-instructions "With GitHub Actions") and delete the `develop` branch.

## Test plan
- [ ] Workflow triggers on merge to master and runs build + security + release jobs
- [ ] NuGet package is published to nuget.org
- [ ] GitHub Release is created with the computed version tag