### PR TITLE
feat: add Size parameter to CopyButton

### DIFF
--- a/Tharga.Blazor/Framework/Buttons/CopyButton.razor
+++ b/Tharga.Blazor/Framework/Buttons/CopyButton.razor
@@ -2,11 +2,14 @@
 @inject IJSRuntime Js
 @inject NotificationService NotificationService
 
-<StandardButton Text="Copy" Icon="content_copy" Click="CopyAction" />
+<StandardButton Text="Copy" Icon="content_copy" Click="CopyAction" Size="@Size" />
 
 @code {
     [Parameter]
     public string Content { get; set; }
+
+    [Parameter]
+    public ButtonSize Size { get; set; }
 
     private async Task CopyAction()
     {


### PR DESCRIPTION
## Summary
Adds a `Size` parameter to `CopyButton` mirroring `Radzen.ButtonSize` (`ExtraSmall` / `Small` / `Medium` / `Large`). Defaults to `Medium` so existing callers see no visual change. The value is passed through to the underlying `StandardButton` (which already has the parameter wired to `RadzenButton`).

Closes the request *"CopyButton needs a Size parameter"* from Quilt4Net.Toolkit.Blazor (Requests.md, 2026-05-09).

## Use case
`Quilt4Net.Toolkit.Blazor/Features/Log/LogSearchView.razor` shows a CorrelationId column with the copy button inline next to an 8-char preview — at the default size the button dominates the row. Consumers can now use `<CopyButton Content="@id" Size="ButtonSize.ExtraSmall" />`.

## Test plan
- [ ] Build succeeds with 0 warnings on .NET 9 and .NET 10
- [ ] Existing 24 tests still pass
- [ ] In a consumer project, `<CopyButton Content="..." Size="ButtonSize.ExtraSmall" />` renders smaller than the default

## Notes
- Targets `develop` per project branching rules. Will be picked up in the next develop → master release.
- No new test added: there's no bUnit infrastructure in `Tharga.Blazor.Tests` (existing tests cover DI registration only) and the change is a single pass-through parameter that compiles checks on the type signature.