### PR TITLE
chore: update nuget packages

### DIFF
--- a/Tharga.Blazor.Tests/Tharga.Blazor.Tests.csproj
+++ b/Tharga.Blazor.Tests/Tharga.Blazor.Tests.csproj
@@ -10,8 +10,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Tharga.Blazor/Tharga.Blazor.csproj
+++ b/Tharga.Blazor/Tharga.Blazor.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <PackageReference Include="Radzen.Blazor" Version="9.0.4" />
-    <PackageReference Include="Tharga.Toolkit" Version="1.15.23" />
+    <PackageReference Include="Tharga.Toolkit" Version="1.15.24" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Routine dependency bumps (all patch-level):

| Package | From | To |
|---|---|---|
| Tharga.Toolkit | 1.15.23 | 1.15.24 |
| Microsoft.Extensions.Options.ConfigurationExtensions | 10.0.7 | 10.0.8 |
| Microsoft.AspNetCore.Components (tests) | 10.0.7 | 10.0.8 |
| Microsoft.Extensions.Configuration (tests) | 10.0.7 | 10.0.8 |

## Test plan
- [ ] CI build succeeds with 0 warnings on .NET 9 and .NET 10
- [ ] All tests pass
- [ ] Release job publishes the next patch (2.1.6)