### PR TITLE
feat: ExpandableCard leading ImageUrl in title (#10)

### DIFF
--- a/Tharga.Blazor/ExpandableCard.razor
+++ b/Tharga.Blazor/ExpandableCard.razor
@@ -3,7 +3,14 @@
 <RadzenCard>
     <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.SpaceBetween" Style="margin: calc(-1 * var(--rz-card-padding)); padding: 1rem; cursor: pointer; border-bottom: 1px solid #d6d5d5;" @onclick="OnToggleSelection">
         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center">
-            <RadzenIcon Icon="@Icon" Visible="@(!string.IsNullOrEmpty(Icon))" />
+            @if (!string.IsNullOrEmpty(ImageUrl))
+            {
+                <img src="@ImageUrl" alt="@Text" style="max-height: var(--rz-icon-size); width: auto;" />
+            }
+            else
+            {
+                <RadzenIcon Icon="@Icon" Visible="@(!string.IsNullOrEmpty(Icon))" />
+            }
             <RadzenText Text="@Text" />
         </RadzenStack>
         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center">
@@ -27,6 +34,14 @@
 
     [Parameter]
     public string Icon { get; set; }
+
+    /// <summary>
+    /// URL of an image to render in the leading title slot, in place of <see cref="Icon"/>.
+    /// When set, the image is shown and <see cref="Icon"/> is ignored. The image height is
+    /// capped to the icon size, preserving aspect ratio.
+    /// </summary>
+    [Parameter]
+    public string ImageUrl { get; set; }
 
     [Parameter]
     public bool AllowSaveState { get; set; } = true;


### PR DESCRIPTION
Closes #10.

## What
Adds a `string ImageUrl` parameter to `ExpandableCard`, rendered in the leading title slot (left of the text) in place of the font `Icon`.

## Behavior
- **Image wins:** when `ImageUrl` is set, the image renders and `Icon` is ignored — they share one leading slot, never both.
- Image height is capped to the icon size via `max-height: var(--rz-icon-size)` with `width: auto`, so large images scale down to icon height and keep their aspect ratio.
- `alt` defaults to the card `Text`.
- Backward compatible: existing callers set only `Icon` and are unaffected.

## Testing
Build clean (0 warnings) and all 24 existing tests pass in Release. No render test was added — the test project has no component-rendering harness (no bUnit), and this is a purely presentational change. Happy to add bUnit coverage in a follow-up if wanted.

## Notes for the consumer (Tharga.Platform)
`ImageUrl` covers the avatar-image case. It does **not** provide an initials-fallback slot for the no-image case (that would have needed the `TitlePrefix` fragment option); Platform keeps rendering initials on its side when there's no avatar URL.