### PR TITLE
chore!: target net10.0 only, consume tier 1, declare licence and project url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,36 +32,15 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build -c Release --no-restore 2>&1 | tee build.log
-
-      - name: Check warnings
-        run: |
-          WARNING_COUNT=$(grep -c " warning " build.log || true)
-          echo "Build warnings: $WARNING_COUNT"
-          if [ "$WARNING_COUNT" -gt 15 ]; then
-            echo "::error::Build has $WARNING_COUNT warnings (threshold: 15)"
-            exit 1
-          fi
-
-      - name: Test with coverage
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          directory: ./coverage
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
+      # Version is computed BEFORE the build so it can be passed as -p:Version.
+      # Passing it only to `dotnet pack` sets PackageVersion alone, leaving
+      # AssemblyVersion and FileVersion at their default 1.0.0.0 inside the
+      # shipped assembly.
       - name: Compute version
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -96,15 +75,50 @@ jobs:
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed pre-release version: $PRE_VERSION"
 
-      - name: Pack (stable — push to master)
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      # Pull requests build the pre-release version, pushes to master the
+      # stable one. One value drives build and pack so the assembly and the
+      # package can never disagree.
+      - name: Resolve build version
+        id: buildversion
+        shell: bash
         run: |
-          dotnet pack Tharga.Blazor/Tharga.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION="${{ steps.preversion.outputs.version }}"
+          else
+            VERSION="${{ steps.version.outputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building as: $VERSION"
 
-      - name: Pack (pre-release — pull request)
-        if: github.event_name == 'pull_request'
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore -p:Version=${{ steps.buildversion.outputs.version }} 2>&1 | tee build.log
+
+      - name: Check warnings
         run: |
-          dotnet pack Tharga.Blazor/Tharga.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          WARNING_COUNT=$(grep -c " warning " build.log || true)
+          echo "Build warnings: $WARNING_COUNT"
+          if [ "$WARNING_COUNT" -gt 15 ]; then
+            echo "::error::Build has $WARNING_COUNT warnings (threshold: 15)"
+            exit 1
+          fi
+
+      - name: Test with coverage
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Pack
+        shell: bash
+        run: |
+          dotnet pack Tharga.Blazor/Tharga.Blazor.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -162,7 +176,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -236,7 +250,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,9 +192,17 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            # This previously ended in `|| true`, which is how symbol pushes
+            # failed silently for months.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Release
@@ -275,9 +283,17 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            # This previously ended in `|| true`, which is how symbol pushes
+            # failed silently for months.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Pre-release

--- a/Tharga.Blazor.Tests/Tharga.Blazor.Tests.csproj
+++ b/Tharga.Blazor.Tests/Tharga.Blazor.Tests.csproj
@@ -10,9 +10,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Tharga.Blazor.sln
+++ b/Tharga.Blazor.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tharga.Blazor", "Tharga.Bla
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1D5D61F6-8BCA-41CF-8B8C-E326A0A16D18}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
+		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Tharga.Blazor/Tharga.Blazor.csproj
+++ b/Tharga.Blazor/Tharga.Blazor.csproj
@@ -1,24 +1,33 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga Blazor</Product>
     <Description>Generic reusable Blazor UI components: buttons, breadcrumbs, error boundaries, and more. Built on Radzen.Blazor.</Description>
     <PackageIconUrl>https://thargelion.net/assets/component-blazor.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Tharga/Blazor</PackageProjectUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <DebugType>portable</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
+    <!-- Without this, pack emits the legacy .symbols.nupkg, which nuget.org
+         rejects as a duplicate of the main package, so no symbols ship. -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591</NoWarn>
+    <!--
+      NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+      Suppressed deliberately. Tharga packages reference their icon from
+      https://thargelion.net/assets/ so all package icons are maintained in one
+      place and can be updated without republishing a package.
+    -->
+    <NoWarn>1701;1702;CS1591;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md">
@@ -28,8 +37,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageReference Include="Radzen.Blazor" Version="10.4.7" />
-    <PackageReference Include="Tharga.Toolkit" Version="1.15.25" />
+    <PackageReference Include="Tharga.Toolkit" Version="1.16.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Tier 2 of the package cleanup sweep.

- **net10.0 only** — dropped net9.0 (out of support 2026-11-10).
- **Tharga.Toolkit 1.15.25 → 1.16.0.** That release requires `Microsoft.Extensions.Options.ConfigurationExtensions >= 10.0.10` while this repo pinned 10.0.9, which failed the build with NU1605. Microsoft packages moved to 10.0.10 to match the rest of the ecosystem; `Microsoft.NET.Test.Sdk` 18.6.0 → 18.8.1.
- **Declared the licence.** The repo has an MIT LICENSE file but the package never said so — every push logged `License missing`. Also added the `PackageProjectUrl`, which was missing entirely.
- **Symbols now actually publish.** `SymbolPackageFormat` was unset, so pack emitted a legacy `.symbols.nupkg`; its filename still ends in `.nupkg`, so the push loop pushed it as a regular package and nuget.org rejected it as a duplicate of the main package. No symbols had ever shipped. Now `snupkg`, which the client pushes alongside the `.nupkg` automatically.
- **Removed `<Version>1.0.0</Version>`** — it disagreed with the 2.2 series CI actually ships.
- CI: version computed before the build and passed as `-p:Version`; tag lookup guarded against a new `MAJOR_MINOR` series; SDK narrowed to 10.0.x.
- Solution items: added the workflow and LICENSE.

24 tests passing.